### PR TITLE
Adapted parsing scripts for EPI models to work with updated JSONs for Epi models

### DIFF
--- a/EPI/parse-nested-CAG.py
+++ b/EPI/parse-nested-CAG.py
@@ -22,18 +22,13 @@ def formatGraph(data):
     
     subgraphs = data['subgraphs']
     for subgraph in subgraphs:
-        # Get parent name
-        parent_name = subgraph['scope']
-        if (parent_name == '@global'):
-            parent_name = 'root'
-
-        # Get container name
-        splitted_id = subgraph['basename'].split('.')
-
         #Get container metadata
         metadata = subgraph['metadata'][0] if 'metadata' in subgraph else {}
 
-        node = { 'id': subgraph['basename'], 'concept': splitted_id[(len(splitted_id) - 1)], 'nodeType': 'container', 'label': splitted_id[(len(splitted_id) - 1)], 'parent': parent_name, 'metadata': metadata }
+        #Get parent id
+        parent_id = 'root' if subgraph['parent'] is None else subgraph['parent'] 
+
+        node = { 'id': subgraph['uid'], 'concept': subgraph['basename'], 'nodeType': 'container', 'label': subgraph['basename'], 'parent': parent_id, 'metadata': metadata }
         formattedNodes.append(node)
         for n in subgraph['nodes']:
             found = n in nodesDict
@@ -42,7 +37,7 @@ def formatGraph(data):
                 # Variables
                 if (found_node['nodeType'] == 'variable'):
                     splitted_identifier = found_node['identifier'].split('::')
-                    node = { 'id': n, 'concept': splitted_identifier[len(splitted_identifier)-2], 'label': splitted_identifier[len(splitted_identifier)-2], 'nodeType': 'variable', 'type': found_node['type'], 'parent': subgraph['basename'], 'metadata': found_node['metadata']}
+                    node = { 'id': n, 'concept': splitted_identifier[len(splitted_identifier)-2], 'label': splitted_identifier[len(splitted_identifier)-2], 'nodeType': 'variable', 'type': found_node['type'], 'parent': subgraph['uid'], 'metadata': found_node['metadata']}
                     formattedNodes.append(node)
                 else: 
                     raise Exception('Unrecognized node type')
@@ -93,7 +88,7 @@ def formatGraph(data):
     
 
     # Append root for visualization purposes so we don't have multiple roots
-    formattedNodes.append({'concept': 'root', 'parent': '', 'id': 'root'}) 
+    formattedNodes.append({'concept': 'root', 'parent': None, 'id': 'root'}) 
     
     return  { 'metadata': modelMetadata, 'nodes': formattedNodes,'edges': formattedEdges }
 

--- a/EPI/parse-nested-CAG.py
+++ b/EPI/parse-nested-CAG.py
@@ -2,95 +2,93 @@ import json
 from argparse import ArgumentParser
 
 
-def formatGraph(data): 
-    modelMetadata = {}
-    nodesDict = {}
-    formattedNodes = []
-    formattedEdges = []
+def populate_types_dict(types, type_name, types_dict):
+    for t in types:
+        if t in types_dict:
+            types_dict[t].append(type_name)
+        else:
+            types_dict[t] = [type_name]
 
-    variables = data['variables']
-    for variable in variables:
+
+def format_graph(data):
+    nodes_dict = {}
+    nodes = []
+    edges = []
+
+    for variable in data['variables']:
         metadata = variable['metadata'][0] if 'metadata' in variable else {}
         variable['nodeType'] = 'variable'
         variable['dataType'] = variable['type']
         variable['metadata'] = metadata
-        nodesDict[variable['uid']] = variable
+        nodes_dict[variable['uid']] = variable
+
+    for cag_edge in data['edges']:
+        edges.append({'source': cag_edge[0], 'target': cag_edge[1]})
     
-    edges = data['edges']
-    for i in range(len(edges)):
-        formattedEdges.append({ 'source': edges[i][0], 'target': edges[i][1]})
-    
-    subgraphs = data['subgraphs']
-    for subgraph in subgraphs:
-        #Get container metadata
+    for subgraph in data['subgraphs']:
+        # Get container metadata
         metadata = subgraph['metadata'][0] if 'metadata' in subgraph else {}
 
-        #Get parent id
+        # Get parent id
         parent_id = 'root' if subgraph['parent'] is None else subgraph['parent'] 
 
-        node = { 'id': subgraph['uid'], 'concept': subgraph['basename'], 'nodeType': 'container', 'label': subgraph['basename'], 'parent': parent_id, 'metadata': metadata }
-        formattedNodes.append(node)
+        nodes.append({
+            'id': subgraph['uid'],
+            'concept': subgraph['basename'],
+            'nodeType': 'container',
+            'label': subgraph['basename'],
+            'parent': parent_id,
+            'metadata': metadata
+        })
         for n in subgraph['nodes']:
-            found = n in nodesDict
-            if (found): 
-                found_node = nodesDict[n]
+            if n in nodes_dict:
+                found_node = nodes_dict[n]
                 # Variables
-                if (found_node['nodeType'] == 'variable'):
+                if found_node['nodeType'] == 'variable':
                     splitted_identifier = found_node['identifier'].split('::')
-                    node = { 'id': n, 'concept': splitted_identifier[len(splitted_identifier)-2], 'label': splitted_identifier[len(splitted_identifier)-2], 'nodeType': 'variable', 'type': found_node['type'], 'parent': subgraph['uid'], 'metadata': found_node['metadata']}
-                    formattedNodes.append(node)
+                    nodes.append({
+                        'id': n,
+                        'concept': splitted_identifier[len(splitted_identifier)-2],
+                        'label': splitted_identifier[len(splitted_identifier)-2],
+                        'nodeType': 'variable',
+                        'type': found_node['type'],
+                        'parent': subgraph['uid'],
+                        'metadata': found_node['metadata']
+                    })
                 else: 
-                    raise Exception('Unrecognized node type')
+                    raise Exception('Unrecognized node type: %s' % found_node['nodeType'])
             else:
-                raise Exception(n + ' Node missing')
- 
+                raise Exception('Node missing: %s' % n)
+
     metadata = data['metadata'] if 'metadata' in data else {}
-    modelMetadata = metadata
 
-    if (modelMetadata):
-        variableTypes = modelMetadata[0]['attributes']
-        variableTypesDict = {}
-        for varType in variableTypes:
-            for i in varType['inputs']:
-                variableTypesDict[i] = ['input']
-            for i in varType['outputs']:
-                variableTypesDict[i] = ['output']
+    if metadata:
+        variable_types = metadata[0]['attributes']
+        variable_types_dict = {}
+        for var_type in variable_types:
+            for i in var_type['inputs']:
+                variable_types_dict[i] = ['input']
+            for i in var_type['outputs']:
+                variable_types_dict[i] = ['output']
 
-            # Distinguish variable type (inputs and outputs can also be classified as model variables, params, initial conditions or internal variables)
-            for i in varType['parameters']:
-                found = i in variableTypesDict
-                if (found):
-                    variableTypesDict[i].append('parameter')
-                else:
-                    variableTypesDict[i] = ['parameter']
-            for i in varType['model_variables']:
-                found = i in variableTypesDict
-                if (found):
-                    variableTypesDict[i].append('model_variable')
-                else:
-                    variableTypesDict[i] = ['model_variable']
-            for i in varType['initial_conditions']:
-                found = i in variableTypesDict
-                if (found):
-                    variableTypesDict[i].append('initial_condition')
-                else:
-                    variableTypesDict[i] = 'initial_condition'
-            for i in varType['internal_variables']:
-                found = i in variableTypesDict
-                if (found):
-                    variableTypesDict[i].append('internal_variable')
-                else:
-                    variableTypesDict[i] = 'internal_variable'
-        
-        for node in formattedNodes:
-            if 'nodeType' in node and node['nodeType'] == 'variable' and node['id'] in variableTypesDict:
-                node['nodeSubType'] = variableTypesDict[node['id']]
-    
+            # Distinguish variable type (inputs and outputs can also be classified as model variables, params,
+            #   initial conditions or internal variables)
+            populate_types_dict(var_type['parameters'], 'parameter', variable_types_dict)
+            populate_types_dict(var_type['model_variables'], 'model_variable', variable_types_dict)
+            populate_types_dict(var_type['initial_conditions'], 'initial_condition', variable_types_dict)
+            populate_types_dict(var_type['internal_variables'], 'internal_variable', variable_types_dict)
+
+        for node in nodes:
+            if 'nodeType' in node and node['nodeType'] == 'variable' and node['id'] in variable_types_dict:
+                node['nodeSubType'] = variable_types_dict[node['id']]
+            else:
+                node['nodeSubType'] = []
 
     # Append root for visualization purposes so we don't have multiple roots
-    formattedNodes.append({'concept': 'root', 'parent': None, 'id': 'root'}) 
+    nodes.append({'concept': 'root', 'parent': None, 'id': 'root'})
     
-    return  { 'metadata': modelMetadata, 'nodes': formattedNodes,'edges': formattedEdges }
+    return {'metadata': metadata, 'nodes': nodes,'edges': edges}
+
 
 if __name__ == '__main__':
     parser = ArgumentParser()
@@ -102,13 +100,7 @@ if __name__ == '__main__':
 
     with open(args.input) as f:
         data = json.load(f)
-        graph = formatGraph(data)
+        graph = format_graph(data)
 
     with open(args.output, 'w') as f:
         json.dump(graph, f)
-
-
-
-
-
-         

--- a/EPI/parse-nested-GrFN.py
+++ b/EPI/parse-nested-GrFN.py
@@ -31,18 +31,13 @@ def formatGraph(data):
 
     subgraphs = data['subgraphs']
     for subgraph in subgraphs:
-        # Get parent name
-        parent_name = subgraph['scope']
-        if (parent_name == '@global'):
-            parent_name = 'root'
-        
-        # Get container name
-        splitted_id = subgraph['basename'].split('.')
-
         #Get container metadata
         metadata = subgraph['metadata'][0] if 'metadata' in subgraph else {}
 
-        node = { 'id': subgraph['basename'], 'concept': splitted_id[(len(splitted_id) - 1)], 'nodeType': 'container', 'dataType': '', 'label': splitted_id[(len(splitted_id) - 1)], 'parent': parent_name, 'metadata': metadata }
+        #Get parent id
+        parent_id = 'root' if subgraph['parent'] is None else subgraph['parent'] 
+
+        node = { 'id': subgraph['uid'], 'concept': subgraph['basename'], 'nodeType': 'container', 'label': subgraph['basename'], 'parent': parent_id, 'metadata': metadata }
         nodes.append(node)
         for n in subgraph['nodes']:
             found = n in nodesDict
@@ -51,10 +46,10 @@ def formatGraph(data):
                 # Variables
                 if (found_node['nodeType'] == 'variable'):
                     splitted_identifier = found_node['identifier'].split('::')
-                    node = { 'id': n, 'concept': splitted_identifier[len(splitted_identifier)-2], 'label': splitted_identifier[len(splitted_identifier)-2], 'nodeType': 'variable', 'dataType': found_node['type'], 'parent': subgraph['basename'], 'metadata': found_node['metadata']}
+                    node = { 'id': n, 'concept': splitted_identifier[len(splitted_identifier)-2], 'label': splitted_identifier[len(splitted_identifier)-2], 'nodeType': 'variable', 'dataType': found_node['type'], 'parent': subgraph['uid'], 'metadata': found_node['metadata']}
                 # Functions
                 elif found_node['nodeType'] == 'function':
-                    node = { 'id': n, 'concept': found_node['type'], 'label': found_node['type'], 'dataType': found_node['type'], 'nodeType': 'function', 'parent': subgraph['basename'], 'metadata': found_node['metadata']}
+                    node = { 'id': n, 'concept': found_node['type'], 'label': found_node['type'], 'dataType': found_node['type'], 'nodeType': 'function', 'parent': subgraph['uid'], 'metadata': found_node['metadata']}
                 else: 
                     raise Exception('Unrecognized node type')
 
@@ -62,7 +57,9 @@ def formatGraph(data):
             else:
                 raise Exception(n + ' Node missing')
 
-    modelMetadata = data['metadata']
+    metadata = data['metadata'] if 'metadata' in data else {}
+    modelMetadata = metadata
+    
     if modelMetadata:
         variableTypes = modelMetadata[0]['attributes']
         variableTypesDict = {}
@@ -104,7 +101,7 @@ def formatGraph(data):
                 node['nodeSubType'] = []
     
     # Append root for visualization purposes so we don't have multiple roots
-    nodes.append({'concept': 'root', 'parent': '', 'id': 'root'}) 
+    nodes.append({'concept': 'root', 'parent': None, 'id': 'root'}) 
     
     return  { 'metadata': modelMetadata, 'nodes': nodes,'edges': edges }
 

--- a/EPI/parse-nested-GrFN.py
+++ b/EPI/parse-nested-GrFN.py
@@ -2,108 +2,112 @@ import json
 from argparse import ArgumentParser
 
 
-def formatGraph(data): 
-    modelMetadata = {}
-    nodesDict = {}
+def populate_types_dict(types, type_name, types_dict):
+    for t in types:
+        if t in types_dict:
+            types_dict[t].append(type_name)
+        else:
+            types_dict[t] = [type_name]
+
+
+def format_graph(data):
+    nodes_dict = {}
     nodes = []
     edges = []
 
-    variables = data['variables']
-    for variable in variables:
+    for variable in data['variables']:
         metadata = variable['metadata'][0] if 'metadata' in variable else {}
         variable['nodeType'] = 'variable'
         variable['dataType'] = variable['type']
         variable['metadata'] = metadata
-        nodesDict[variable['uid']] = variable
+        nodes_dict[variable['uid']] = variable
    
-    functions = data['functions']
-    for function in functions:
+    for function in data['functions']:
         metadata = function['metadata'][0] if 'metadata' in function else {}
         function['nodeType'] = 'function'
         function['dataType'] = function['type']
         function['metadata'] = metadata
-        nodesDict[function['uid']] = function
+        nodes_dict[function['uid']] = function
     
-    hyperEdges = data['hyper_edges']
-    for edge in hyperEdges: 
-        [edges.append({ 'source': i, 'target': edge['function']}) for i in edge['inputs']]
-        [edges.append({ 'source': edge['function'], 'target': o }) for o in edge['outputs']]
+    for edge in data['hyper_edges']:
+        [edges.append({'source': i, 'target': edge['function']}) for i in edge['inputs']]
+        [edges.append({'source': edge['function'], 'target': o}) for o in edge['outputs']]
 
-    subgraphs = data['subgraphs']
-    for subgraph in subgraphs:
-        #Get container metadata
+    for subgraph in data['subgraphs']:
+        # Get container metadata
         metadata = subgraph['metadata'][0] if 'metadata' in subgraph else {}
 
-        #Get parent id
+        # Get parent id
         parent_id = 'root' if subgraph['parent'] is None else subgraph['parent'] 
 
-        node = { 'id': subgraph['uid'], 'concept': subgraph['basename'], 'nodeType': 'container', 'label': subgraph['basename'], 'parent': parent_id, 'metadata': metadata }
-        nodes.append(node)
+        nodes.append({
+            'id': subgraph['uid'],
+            'concept': subgraph['basename'],
+            'nodeType': 'container',
+            'label': subgraph['basename'],
+            'parent': parent_id,
+            'metadata': metadata
+        })
         for n in subgraph['nodes']:
-            found = n in nodesDict
-            if (found): 
-                found_node = nodesDict[n]
+            if n in nodes_dict:
+                found_node = nodes_dict[n]
                 # Variables
-                if (found_node['nodeType'] == 'variable'):
+                if found_node['nodeType'] == 'variable':
                     splitted_identifier = found_node['identifier'].split('::')
-                    node = { 'id': n, 'concept': splitted_identifier[len(splitted_identifier)-2], 'label': splitted_identifier[len(splitted_identifier)-2], 'nodeType': 'variable', 'dataType': found_node['type'], 'parent': subgraph['uid'], 'metadata': found_node['metadata']}
+                    nodes.append({
+                        'id': n,
+                        'concept': splitted_identifier[len(splitted_identifier)-2],
+                        'label': splitted_identifier[len(splitted_identifier)-2],
+                        'nodeType': 'variable',
+                        'dataType': found_node['type'],
+                        'parent': subgraph['uid'],
+                        'metadata': found_node['metadata']
+                    })
                 # Functions
                 elif found_node['nodeType'] == 'function':
-                    node = { 'id': n, 'concept': found_node['type'], 'label': found_node['type'], 'dataType': found_node['type'], 'nodeType': 'function', 'parent': subgraph['uid'], 'metadata': found_node['metadata']}
+                    nodes.append({
+                        'id': n,
+                        'concept': found_node['type'],
+                        'label': found_node['type'],
+                        'dataType': found_node['type'],
+                        'nodeType': 'function',
+                        'parent': subgraph['uid'],
+                        'metadata': found_node['metadata']
+                    })
                 else: 
-                    raise Exception('Unrecognized node type')
-
-                nodes.append(node)
+                    raise Exception('Unrecognized node type: %s' % found_node['nodeType'])
             else:
-                raise Exception(n + ' Node missing')
+                raise Exception('Node missing: %s' % n)
 
     metadata = data['metadata'] if 'metadata' in data else {}
-    modelMetadata = metadata
-    
-    if modelMetadata:
-        variableTypes = modelMetadata[0]['attributes']
-        variableTypesDict = {}
-        for varType in variableTypes:
-            for i in varType['inputs']:
-                variableTypesDict[i] = ['input']
-            for i in varType['outputs']:
-                variableTypesDict[i] = ['output']
-            
-            # Distinguish variable type (inputs and outputs can also be classified as model variables, params, initial conditions or internal variables)
-            for i in varType['parameters']:
-                found = i in variableTypesDict
-                if (found):
-                    variableTypesDict[i].append('parameter')
-                else:
-                    variableTypesDict[i] = ['parameter']
-            for i in varType['model_variables']:
-                found = i in variableTypesDict
-                if (found):
-                    variableTypesDict[i].append('model_variable')
-                else:
-                    variableTypesDict[i] = ['model_variable']
-            for i in varType['initial_conditions']:
-                found = i in variableTypesDict
-                if (found):
-                    variableTypesDict[i].append('initial_condition')
-                else:
-                    variableTypesDict[i] = 'initial_condition'
-            for i in varType['internal_variables']:
-                found = i in variableTypesDict
-                if (found):
-                    variableTypesDict[i].append('internal_variable')
-                else:
-                    variableTypesDict[i] = 'internal_variable'
+
+    if metadata:
+        variable_types = metadata[0]['attributes']
+        variable_types_dict = {}
+        for var_type in variable_types:
+            for i in var_type['inputs']:
+                variable_types_dict[i] = ['input']
+            for i in var_type['outputs']:
+                variable_types_dict[i] = ['output']
+
+            # Distinguish variable type (inputs and outputs can also be classified as model variables, params,
+            #   initial conditions or internal variables)
+            populate_types_dict(var_type['parameters'], 'parameter', variable_types_dict)
+            populate_types_dict(var_type['model_variables'], 'model_variable', variable_types_dict)
+            populate_types_dict(var_type['initial_conditions'], 'initial_condition', variable_types_dict)
+            populate_types_dict(var_type['internal_variables'], 'internal_variable', variable_types_dict)
+
         for node in nodes:
-            if 'nodeType' in node and node['nodeType'] == 'variable' and node['id'] in variableTypesDict:
-                node['nodeSubType'] = variableTypesDict[node['id']]
+            if 'nodeType' in node and node['nodeType'] == 'variable' and node['id'] in variable_types_dict:
+                node['nodeSubType'] = variable_types_dict[node['id']]
             else:
                 node['nodeSubType'] = []
-    
+
     # Append root for visualization purposes so we don't have multiple roots
-    nodes.append({'concept': 'root', 'parent': None, 'id': 'root'}) 
+    nodes.append({'concept': 'root', 'parent': None, 'id': 'root'})
     
-    return  { 'metadata': modelMetadata, 'nodes': nodes,'edges': edges }
+    return {'metadata': metadata, 'nodes': nodes,'edges': edges}
+
 
 if __name__ == '__main__':
     parser = ArgumentParser()
@@ -115,13 +119,7 @@ if __name__ == '__main__':
 
     with open(args.input) as f:
         data = json.load(f)
-        graph = formatGraph(data)
+        graph = format_graph(data)
 
     with open(args.output, 'w') as f:
         json.dump(graph, f)
-
-
-
-
-
-         

--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ Fetch the ASKE files from the Minio server. From the root of the project:
 $ python get_files.py
 ```
 This will create a folder, `aske_files`, in the root of the project. The folder is not under version control.
+The local target directory name can be changed by supplying the `--dir` argument. Also, by providing the 
+`--prefix` argument, only certain content will be downloaded (e.g. `--prefix research/EPI`). 
+NOTE: All the content in the local target directory will be deleted before fetching the files from the storage.

--- a/get_files.py
+++ b/get_files.py
@@ -1,15 +1,28 @@
 import os
 import sys
+import shutil
 from argparse import ArgumentParser
 
 from minio import Minio
 from tqdm import tqdm
 
+
 if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument('--secure', '-s', action="store_true",
                         help='the Minio server connection should be secure')
+    parser.add_argument('--prefix', '-p', default="",
+                        help='the folder prefix to download (e.g. "research/EPI")')
+    parser.add_argument('--dir', '-d', default="aske_files",
+                        help='the folder in which the downloaded files should be placed')
     args = parser.parse_args()
+
+    root_dir = args.dir
+    target_dir = os.path.join(root_dir, args.prefix)
+    # delete the local target directory if it exists, to ensure that the
+    #   local contents are in sync with Minio after fetching
+    if os.path.exists(target_dir):
+        shutil.rmtree(target_dir)
 
     with open(".local", "rt") as f:
 
@@ -21,11 +34,15 @@ if __name__ == '__main__':
             print("Could not find a bucket called 'aske'")
             sys.exit(1)
 
-        objects = [o for o in minio_client.list_objects("aske", recursive=True)]
+        objects = [o for o in minio_client.list_objects("aske", prefix=args.prefix, recursive=True)]
+
+        if not objects:
+            print("No objects with prefix '%s' found in 'aske' bucket" % args.prefix)
+            sys.exit(1)
 
         for obj in tqdm(objects):
             directory, filename = obj.object_name.rsplit('/', 1)
-            dir_path = os.path.join("aske_files", directory)
+            dir_path = os.path.join(root_dir, directory)
             os.makedirs(dir_path, exist_ok=True)
             minio_client.fget_object(bucket_name="aske", object_name=obj.object_name,
                                      file_path=os.path.join(dir_path, filename))


### PR DESCRIPTION
Arizona has updated their JSONs for CAGs and GrFNs so it is easier for us to generate the hierarchy. Particularly, they have included an `uid` for subgraphs and a `parent` attribute. This PR updates our parsing scripts to include those updates and visualize the models properly nested.

To test:
- Updated version of the CAGs and GrFNs: http://10.64.18.171:9000/minio/aske/research/EPI/data/ (you can test it out with CHIME, SIR, and the Double Epidemic model). It seems that the Gillespie JSONs do not include these updates. 